### PR TITLE
fix(essentials): make timer support node

### DIFF
--- a/.changeset/angry-bobcats-provide.md
+++ b/.changeset/angry-bobcats-provide.md
@@ -1,0 +1,5 @@
+---
+"@codedazur/essentials": patch
+---
+
+the Timer no longer fails during node processes

--- a/.changeset/yellow-apricots-scream.md
+++ b/.changeset/yellow-apricots-scream.md
@@ -1,0 +1,5 @@
+---
+"@codedazur/react-preferences": major
+---
+
+stable release


### PR DESCRIPTION
Avoid using `window` directly to support the NodeJS `setTimeout` function , and make `_timer` class attribute support the `NodeJS.Timeout` type.