### PR TITLE
hide siblings on mobile pagination

### DIFF
--- a/.changeset/lemon-peaches-give.md
+++ b/.changeset/lemon-peaches-give.md
@@ -1,0 +1,5 @@
+---
+"@codedazur/react-pagination": minor
+---
+
+make pagination responsive

--- a/packages/react-pagination/hooks/usePagination.test.ts
+++ b/packages/react-pagination/hooks/usePagination.test.ts
@@ -60,6 +60,27 @@ describe("usePagination ", () => {
 
       expect(result.current.page).toBe(1);
     });
+
+    it("should handle mobile view: only show 1 boundaries", () => {
+      const { result } = renderHook(() =>
+        usePagination({
+          pages: 20,
+          initialPage: 1,
+          siblings: 1,
+          boundaries: 2,
+          isMobile: true,
+        }),
+      );
+
+      expect(result.current.range).toEqual([[1, 2, 3], [20]]);
+
+      act(() => {
+        result.current.setPage(2);
+      });
+
+      // // The layout of the segments should still be the same.
+      expect(result.current.range).toEqual([[1, 2, 3], [20]]);
+    });
   });
 
   describe("Array-based pagination", () => {

--- a/packages/react-pagination/hooks/usePagination.ts
+++ b/packages/react-pagination/hooks/usePagination.ts
@@ -20,6 +20,7 @@ interface UsePaginationBaseProps {
   boundaries: number;
 
   gapSize?: number;
+  isMobile?: boolean;
 }
 
 export interface UsePaginationWithPagesProps extends UsePaginationBaseProps {
@@ -101,25 +102,38 @@ export function usePagination<T>(
     [clampIndex],
   );
 
-  const { boundaries = 1, siblings = 1, gapSize = 1 } = props;
+  const { boundaries = 1, siblings = 1, gapSize = 1, isMobile = false } = props;
+
+  const responsiveSiblings = isMobile ? 0 : siblings;
+  const responsiveBoundaries = isMobile ? 1 : boundaries;
 
   const range = useMemo(() => {
     const segments: [number[], number[], number[]] = [
       boundaries ? clampedSequence(1, boundaries) : [],
-      clampedSequence(page - siblings, page + siblings),
-      boundaries
-        ? clampedSequence(computedPages + 1 - boundaries, computedPages)
+      clampedSequence(page - responsiveSiblings, page + responsiveSiblings),
+      responsiveBoundaries
+        ? clampedSequence(
+            computedPages + 1 - responsiveBoundaries,
+            computedPages,
+          )
         : [],
     ];
 
     return formatSegments(
       segments,
       computedPages,
-      siblings,
-      boundaries,
+      responsiveSiblings,
+      responsiveBoundaries,
       gapSize,
     );
-  }, [page, boundaries, siblings, clampedSequence, computedPages, gapSize]);
+  }, [
+    page,
+    responsiveBoundaries,
+    responsiveSiblings,
+    clampedSequence,
+    computedPages,
+    gapSize,
+  ]);
 
   const currentItems = useMemo(
     () =>


### PR DESCRIPTION
https://codedazur.atlassian.net/browse/IW-987 

This is a suggested solution to the overflow of the pagination on mobile - IMC related ticket. The design is a bit different than this recommended approach but to me this solution is less invasive still resolving the overflow issue on mobile. 

Suggested approach (we hide siblings on mobile):
 
<img width="344" alt="Screenshot 2024-10-01 at 12 14 52" src="https://github.com/user-attachments/assets/a3594138-eba9-41f8-b456-fa42b6d6ec93">

IMC Design:
<img width="504" alt="Screenshot 2024-10-01 at 13 47 30" src="https://github.com/user-attachments/assets/8f54556b-c1e5-4b74-87e6-303448861bd1">

