### PR TITLE
Feature/add metadata to tracking

### DIFF
--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29351,7 +29351,7 @@
     },
     "packages/cdk-docker-cluster": {
       "name": "@codedazur/cdk-docker-cluster",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@codedazur/cdk-site-distribution": "^1.0.0"
@@ -30204,10 +30204,10 @@
     },
     "packages/cdk-next-app": {
       "name": "@codedazur/cdk-next-app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@codedazur/cdk-docker-cluster": "^1.0.0"
+        "@codedazur/cdk-docker-cluster": "^1.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -32558,7 +32558,7 @@
     },
     "packages/react-tracking": {
       "name": "@codedazur/react-tracking",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@codedazur/essentials": "^1.9.1",

--- a/packages/react-tracking/components/TrackingProvider.tsx
+++ b/packages/react-tracking/components/TrackingProvider.tsx
@@ -28,7 +28,7 @@ export interface TrackingProviderProps {
   slug?: string;
   tracker?: Tracker | Promise<Tracker> | false;
   children?: ReactNode;
-  metadata?: TrackingMetadata;
+  metadata: TrackingMetadata | null;
 }
 
 export type TrackingMetadata = Record<string, string>;
@@ -41,7 +41,7 @@ export function TrackingProvider({
   slug,
   tracker,
   children,
-  metadata, 
+  metadata = null, 
 }: TrackingProviderProps) {
   const parent = usePrivateTracker();
 

--- a/packages/react-tracking/contexts/trackingContext.ts
+++ b/packages/react-tracking/contexts/trackingContext.ts
@@ -14,7 +14,7 @@ export interface TrackingContext {
   trackEnter: (element: Element) => Promise<void>;
   trackExit: (element: Element) => Promise<void>;
   trackLoad: (event: SyntheticEvent<Element>) => Promise<void>;
-  metadata?: TrackingMetadata;
+  metadata: TrackingMetadata | null;
 }
 
 export enum TrackingEventType {
@@ -114,5 +114,5 @@ export const trackingContext = createContext<TrackingContext>({
   trackEnter: async () => undefined,
   trackExit: async () => undefined,
   trackLoad: async () => undefined,
-  metadata: undefined,
+  metadata: null,
 });

--- a/packages/react-tracking/contexts/trackingContext.ts
+++ b/packages/react-tracking/contexts/trackingContext.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { MouseEvent, SyntheticEvent, createContext } from "react";
-import { Tracker } from "../components/TrackingProvider";
+import { Tracker, TrackingMetadata } from "../components/TrackingProvider";
 
 export interface TrackingContext {
   path: string[];
@@ -14,6 +14,7 @@ export interface TrackingContext {
   trackEnter: (element: Element) => Promise<void>;
   trackExit: (element: Element) => Promise<void>;
   trackLoad: (event: SyntheticEvent<Element>) => Promise<void>;
+  metadata?: TrackingMetadata;
 }
 
 export enum TrackingEventType {
@@ -29,7 +30,7 @@ export interface EventMetadata {
   path: string;
 }
 
-export type TrackingEvent = BaseEvent | PageEvent | ElementEvent;
+export type TrackingEvent = BaseEvent | PageEvent | ElementEvent ;
 
 export interface BaseEvent {
   type: string;
@@ -40,6 +41,7 @@ export interface PageEvent extends BaseEvent {
   type: string;
   data: {
     page: PageData;
+    metadata?: TrackingMetadata;
   };
 }
 
@@ -48,6 +50,7 @@ export interface ElementEvent extends BaseEvent {
   data: {
     page: PageData;
     element: ElementData;
+    metadata?: TrackingMetadata;
   };
 }
 
@@ -111,4 +114,5 @@ export const trackingContext = createContext<TrackingContext>({
   trackEnter: async () => undefined,
   trackExit: async () => undefined,
   trackLoad: async () => undefined,
+  metadata: undefined,
 });


### PR DESCRIPTION
This is a POC to add optional metadata to TrackingProvider to support IMC with Job Related Tracking: 

https://codedazur.atlassian.net/browse/IW-1261

The way it works by adding: metadata to TrackingProvider  then metadata render under data object:

```
 <TrackingProvider
          metadata={{ id: "PlaceholderJobId", title: "Machine Learning" }}
        >
```

Tested in fusion:

<img width="500" alt="Screenshot 2025-02-18 at 16 55 22" src="https://github.com/user-attachments/assets/a4cbc479-83ad-4c23-a5a4-0bc8f0b0fca3" />
<img width="500" alt="Screenshot 2025-02-18 at 16 54 13" src="https://github.com/user-attachments/assets/0f713034-5647-403d-a110-43ef60379a85" />

If not set metadata will be undefined. I was trying to not render anything at all when metadata is not set but I had difficulty achieving that, I hope for some input on this:

<img width="500" alt="Screenshot 2025-02-18 at 16 32 27" src="https://github.com/user-attachments/assets/5cb4f4b9-8731-476a-a6b5-55327da48bcf" />



